### PR TITLE
Fix time parsing for events without minutes

### DIFF
--- a/src/calendar_generator.py
+++ b/src/calendar_generator.py
@@ -119,15 +119,23 @@ class CalendarGenerator:
             if time_str:
                 # Handle formats like "8:00 PM", "3:30 PM"
                 time_str_clean = time_str.replace(' ', '').upper()
-                
+
                 if 'PM' in time_str_clean:
                     time_part = time_str_clean.replace('PM', '')
-                    hour, minute = map(int, time_part.split(':'))
+                    if ':' in time_part:
+                        hour, minute = map(int, time_part.split(':'))
+                    else:
+                        hour = int(time_part)
+                        minute = 0
                     if hour != 12:
                         hour += 12
                 elif 'AM' in time_str_clean:
                     time_part = time_str_clean.replace('AM', '')
-                    hour, minute = map(int, time_part.split(':'))
+                    if ':' in time_part:
+                        hour, minute = map(int, time_part.split(':'))
+                    else:
+                        hour = int(time_part)
+                        minute = 0
                     if hour == 12:
                         hour = 0
                 else:

--- a/src/processor.py
+++ b/src/processor.py
@@ -387,13 +387,13 @@ class EventProcessor:
             
             # Extract hour from time string like "2:30 PM"
             import re
-            time_match = re.search(r'(\d{1,2}):(\d{2})\s*([AP]M)', time_str.upper())
+            time_match = re.search(r'(\d{1,2})(?::(\d{2}))?\s*([AP]M)', time_str.upper())
             if not time_match:
                 return False
-            
-            hour, minute, ampm = time_match.groups()
-            hour = int(hour)
-            minute = int(minute)
+
+            hour = int(time_match.group(1))
+            minute = int(time_match.group(2)) if time_match.group(2) else 0
+            ampm = time_match.group(3)
             
             # Convert to 24-hour format
             if ampm == 'PM' and hour != 12:

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -150,8 +150,8 @@ class AFSScraper:
                     if i + 1 < len(lines):
                         time_line += ' ' + lines[i + 1]
                     
-                    # Look for time patterns like "8:00 PM", "3:30 PM", etc.
-                    time_match = re.search(r'(\d{1,2}:\d{2}\s*[AP]M)', time_line, re.IGNORECASE)
+                    # Look for time patterns like "8:00 PM" or "8 PM"
+                    time_match = re.search(r'(\d{1,2}(?::\d{2})?\s*[AP]M)', time_line, re.IGNORECASE)
                     if time_match:
                         return time_match.group(1)
             


### PR DESCRIPTION
## Summary
- support time strings without minutes in the scraper
- handle times like `7 PM` in work hours check
- parse time strings without minutes when generating calendar events

## Testing
- `python -m py_compile src/scraper.py src/processor.py src/calendar_generator.py`
- `python -m py_compile update_website_data.py update_website_data_incremental.py update_website_data_configurable.py main.py fix_book_clubs.py update_book_titles.py`
- `python test_book_club_scrapers.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python test_duplicate_detection.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6852f5385fe88332942bad2a1f2949a5