### PR TITLE
UI tweaks for calendar page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>Culture Calendar - Austin Cultural Events</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=UnifrakturMaguntia&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -16,10 +16,6 @@
             <span class="divider"></span>
             <span class="location">Austin</span>
         </div>
-        <div class="header-center">
-            <button id="list-view-btn" class="view-toggle active">List</button>
-            <button id="calendar-view-btn" class="view-toggle">Calendar</button>
-        </div>
         <div class="header-right">
             <nav class="nav-rail">
                 <a href="#" class="nav-link active">Today</a>
@@ -27,37 +23,10 @@
                 <a href="#" class="nav-link">Calendar</a>
                 <a href="#" class="nav-link">Venues</a>
             </nav>
-            <button class="icon-btn" id="filter-btn">Filter ▼</button>
-            <div class="sort-dropdown">
-                <button class="icon-btn" id="sort-btn">Sort ▼</button>
-                <div class="sort-menu" id="sort-menu">
-                    <button class="sort-option active" data-sort="chronological">Chronological</button>
-                    <button class="sort-option" data-sort="rating">Rating (High to Low)</button>
-                </div>
-            </div>
         </div>
     </header>
 
     <main class="container">
-        <!-- Disclaimer Section -->
-        <section class="disclaimer">
-            <p><strong>Note:</strong> Ratings reflect personal preferences focusing on artistic excellence and aesthetic beauty.
-            Film events exclude work hours (9am-6pm weekdays).
-            Events sourced from <a href="https://www.austinfilm.org" target="_blank">Austin Film Society</a>,
-            <a href="https://hyperrealfilm.club" target="_blank">Hyperreal Film Club</a>,
-            <a href="https://www.austinparamount.com" target="_blank">Paramount Theatre</a>,
-            <a href="https://austinsymphony.org" target="_blank">Austin Symphony Orchestra</a>,
-            <a href="https://www.early-music.org" target="_blank">Texas Early Music Project</a>,
-            <a href="https://www.lafolliaaustin.org" target="_blank">La Follia Austin</a>,
-            <a href="https://www.alienatedmajestybooks.com" target="_blank">Alienated Majesty Books</a>, and
-            <a href="https://www.firstlightaustin.com" target="_blank">First Light Austin</a>.</p>
-        </section>
-
-        <section class="update-info">
-            <h3>Data Last Updated</h3>
-            <ul id="update-list"></ul>
-            <p id="code-updated">Code updated: loading...</p>
-        </section>
 
         <!-- Classical Music Data Warning -->
         <section id="classical-data-warning" class="classical-warning" style="display: none;">
@@ -116,6 +85,13 @@
         <!-- Events List Section -->
         <section class="movies-section" id="list-view">
             <h2>All Upcoming Events</h2>
+            <div class="sort-dropdown results-sort">
+                <button class="icon-btn" id="sort-btn">Sort ▼</button>
+                <div class="sort-menu" id="sort-menu">
+                    <button class="sort-option active" data-sort="chronological">Chronological</button>
+                    <button class="sort-option" data-sort="rating">Rating (High to Low)</button>
+                </div>
+            </div>
             <div id="loading" class="loading">Loading event data...</div>
             <div id="movies-list" class="movies-list"></div>
         </section>
@@ -138,6 +114,26 @@
             </div>
             <div id="calendar-loading" class="loading" style="display: none;">Loading calendar...</div>
             <div id="calendar-container" class="calendar-container"></div>
+        </section>
+
+        <!-- Disclaimer Section relocated -->
+        <section class="disclaimer">
+            <p><strong>Note:</strong> Ratings reflect personal preferences focusing on artistic excellence and aesthetic beauty.
+            Film events exclude work hours (9am-6pm weekdays).
+            Events sourced from <a href="https://www.austinfilm.org" target="_blank">Austin Film Society</a>,
+            <a href="https://hyperrealfilm.club" target="_blank">Hyperreal Film Club</a>,
+            <a href="https://www.austinparamount.com" target="_blank">Paramount Theatre</a>,
+            <a href="https://austinsymphony.org" target="_blank">Austin Symphony Orchestra</a>,
+            <a href="https://www.early-music.org" target="_blank">Texas Early Music Project</a>,
+            <a href="https://www.lafolliaaustin.org" target="_blank">La Follia Austin</a>,
+            <a href="https://www.alienatedmajestybooks.com" target="_blank">Alienated Majesty Books</a>, and
+            <a href="https://www.firstlightaustin.com" target="_blank">First Light Austin</a>.</p>
+        </section>
+
+        <section class="update-info">
+            <h3>Data Last Updated</h3>
+            <ul id="update-list"></ul>
+            <p id="code-updated">Code updated: loading...</p>
         </section>
     </main>
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -81,13 +81,17 @@ function setupEventListeners() {
         downloadFilteredCalendar(minRating);
     });
 
-    listViewBtn.addEventListener('click', function() {
-        switchToListView();
-    });
+    if (listViewBtn) {
+        listViewBtn.addEventListener('click', function() {
+            switchToListView();
+        });
+    }
 
-    calendarViewBtn.addEventListener('click', function() {
-        switchToCalendarView();
-    });
+    if (calendarViewBtn) {
+        calendarViewBtn.addEventListener('click', function() {
+            switchToCalendarView();
+        });
+    }
 
     specialEventsToggle.addEventListener('click', function() {
         toggleSpecialEventsFilter();
@@ -276,8 +280,8 @@ function toggleFilterDrawer() {
 function switchToListView() {
     listView.style.display = 'block';
     calendarView.style.display = 'none';
-    listViewBtn.classList.add('active');
-    calendarViewBtn.classList.remove('active');
+    if (listViewBtn) listViewBtn.classList.add('active');
+    if (calendarViewBtn) calendarViewBtn.classList.remove('active');
 }
 
 // Switch to calendar view
@@ -287,8 +291,8 @@ function switchToCalendarView() {
     try {
         listView.style.display = 'none';
         calendarView.style.display = 'block';
-        listViewBtn.classList.remove('active');
-        calendarViewBtn.classList.add('active');
+        if (listViewBtn) listViewBtn.classList.remove('active');
+        if (calendarViewBtn) calendarViewBtn.classList.add('active');
         
         console.log('Movies data length:', moviesData.length); // Debug log
         

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,7 +6,7 @@
 }
 
 body {
-    font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+    font-family: Georgia, 'Times New Roman', Times, serif;
     font-weight: 400;
     line-height: 1.6;
     color: #111;
@@ -34,9 +34,9 @@ body {
 }
 
 .brand {
-    font-family: 'Charter', Georgia, serif;
-    font-size: 20px;
-    font-weight: 700;
+    font-family: 'UnifrakturMaguntia', cursive;
+    font-size: 32px;
+    font-weight: 400;
 }
 
 .divider {
@@ -48,7 +48,7 @@ body {
 }
 
 .location {
-    font-family: 'Inter', sans-serif;
+    font-family: Georgia, 'Times New Roman', Times, serif;
     font-size: 12px;
     text-transform: uppercase;
     color: #777;
@@ -62,7 +62,7 @@ body {
 
 .view-toggle {
     padding: 0.25rem 1rem;
-    font-family: 'Inter', sans-serif;
+    font-family: Georgia, 'Times New Roman', Times, serif;
     font-size: 12px;
     border-radius: 16px;
     border: 1px solid #ccc;
@@ -122,6 +122,10 @@ body {
 .sort-dropdown {
     position: relative;
     display: inline-block;
+}
+
+.results-sort {
+    margin: 1rem 0;
 }
 
 .sort-menu {
@@ -633,7 +637,7 @@ main {
     border: 1px solid #ddd;
     padding: 0.4rem 0.8rem;
     border-radius: 3px;
-    font-family: 'Inter', sans-serif;
+    font-family: Georgia, 'Times New Roman', Times, serif;
     font-weight: 600;
     font-size: 14px;
     margin-left: auto;


### PR DESCRIPTION
## Summary
- restyle site with NYTimes-inspired fonts
- move sort dropdown above results
- remove unused list/calendar buttons and filter button
- relocate update timestamps and notes to bottom
- add null checks in JS for removed buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f1c7b56c8332b5328d16a5efd1fb