### PR TITLE
Improve event card layout

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -741,6 +741,15 @@ function createMovieCard(movie) {
         stampHtml = '<span class="quality-stamp">★</span>';
     }
 
+    const metaParts = [];
+    if (movie.director) metaParts.push(`Dir. ${escapeHtml(movie.director)}`);
+    if (movie.country) metaParts.push(movie.country);
+    if (movie.year) metaParts.push(movie.year);
+    if (movie.language && movie.language !== 'English') metaParts.push(movie.language);
+    if (movie.duration) metaParts.push(movie.duration);
+    if (movie.venue) metaParts.push(getVenueName(movie.venue));
+    const metaHtml = metaParts.length ? `<div class="movie-subtitle">${metaParts.join(' • ')}</div>` : '';
+
     // Create screening tags with safety check
     const screeningTags = (movie.screenings && Array.isArray(movie.screenings)) 
         ? movie.screenings.map(screening => {
@@ -754,27 +763,18 @@ function createMovieCard(movie) {
     
     return `
         <div class="movie-card">
+            ${stampHtml}
             <div class="movie-header">
                 <h3 class="movie-title">${escapeHtml(movie.title)}</h3>
-                <div class="movie-rating">★ ${finalRating || 'N/A'}/10 ${boostHtml} ${stampHtml}</div>
+                <div class="movie-rating">${finalRating || 'N/A'}/10 ${boostHtml}</div>
                 ${needsExpansion ? `<button class="collapse-button toggle-button" data-movie-id="${movie.id || 'unknown'}" style="display:none">Hide</button>` : ''}
             </div>
-            
-            <div class="movie-info">
-                <div class="movie-badges">
-                    ${movie.duration ? `<span class="movie-meta-badge">${movie.duration}</span>` : ''}
-                    ${movie.director ? `<span class="movie-meta-badge director-badge" data-director="${escapeHtml(movie.director)}">Dir. ${escapeHtml(movie.director)}</span>` : ''}
-                    ${movie.country ? `<span class="country-badge">${movie.country}</span>` : ''}
-                    ${movie.year ? `<span class="year-badge">${movie.year}</span>` : ''}
-                    ${movie.language && movie.language !== 'English' ? `<span class="language-badge">${movie.language}</span>` : ''}
-                    ${movie.venue ? `<span class="venue-badge venue-${movie.venue.toLowerCase()}">${getVenueName(movie.venue)}</span>` : ''}
-                </div>
-                <div class="screenings-container">
-                    ${screeningTags}
-                    ${movie.isSpecialScreening ? '<span class="special-screening-indicator">Special Screening</span>' : ''}
-                </div>
+            ${metaHtml}
+            <div class="screenings-container">
+                ${screeningTags}
+                ${movie.isSpecialScreening ? '<span class="special-screening-indicator">Special Screening</span>' : ''}
             </div>
-            
+
             <div class="movie-description">
                 <div class="description-preview" id="preview-${movie.id || 'unknown'}">
                     ${formatDescription(shortDescription)}

--- a/docs/style.css
+++ b/docs/style.css
@@ -608,6 +608,7 @@ main {
     border-radius: 4px;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
     min-height: 160px;
+    position: relative;
 }
 
 .movie-card:hover {
@@ -635,6 +636,13 @@ main {
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+}
+
+.movie-subtitle {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 0.85rem;
+    color: #555;
+    margin-bottom: 0.75rem;
 }
 
 .movie-rating {
@@ -667,8 +675,10 @@ main {
     padding: 0.2rem 0.6rem;
     border-radius: 12px;
     font-size: 0.8rem;
-    margin-left: 0.5rem;
     font-family: 'EB Garamond', serif;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
 }
 
 .movie-info {
@@ -681,8 +691,6 @@ main {
     gap: 0.4rem;
     margin-bottom: 0.5rem;
     line-height: 1.4;
-    max-height: 2.8rem;
-    overflow: hidden;
 }
 
 .movie-meta-badge {
@@ -793,8 +801,6 @@ main {
     gap: 0.5rem;
     margin-bottom: 1.5rem;
     line-height: 1.4;
-    max-height: 3rem;
-    overflow: hidden;
 }
 
 .screening-tag {


### PR DESCRIPTION
## Summary
- add structured subtitle text on event cards
- show golden star overlay for highly rated events
- allow multi-line badges and screening lists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: firecrawl)*

------
https://chatgpt.com/codex/tasks/task_e_6855fe1d77008332b998aa26215fca5c