### PR TITLE
Fix filter drawer toggle

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -1647,13 +1647,15 @@ function getEarliestEventDate(event) {
 
 // Toggle filter drawer
 function toggleFilterDrawer() {
-    const isVisible = filterDrawer.style.display !== 'none';
-    
-    if (isVisible) {
+    const isOpen = filterDrawer.classList.contains('open');
+
+    if (isOpen) {
+        filterDrawer.classList.remove('open');
         filterDrawer.style.display = 'none';
         showFiltersBtn.textContent = 'Show Filters ▸';
     } else {
         filterDrawer.style.display = 'block';
+        filterDrawer.classList.add('open');
         showFiltersBtn.textContent = 'Hide Filters ▾';
     }
 }


### PR DESCRIPTION
## Summary
- fix the script to properly open and close the filter drawer when clicking **Show Filters**

## Testing
- `grep -n toggleFilterDrawer -n docs/script.js | tail`

------
https://chatgpt.com/codex/tasks/task_e_68582a5831588332bbab83fc78c1699f