### PR TITLE
Fix search bar to check multiple fields

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -679,9 +679,18 @@ function updateFilteredEvents() {
             return false;
         }
 
-        // Search filter (description)
+        // Search filter (title, director, one-liner, description)
         if (searchTerm) {
-            const haystack = (movie.description || '').toLowerCase();
+            const fields = [
+                movie.title,
+                movie.director,
+                movie.oneLinerSummary,
+                movie.description,
+            ];
+            const haystack = fields
+                .filter(Boolean)
+                .join(' ') // combine fields
+                .toLowerCase();
             if (!haystack.includes(searchTerm)) {
                 return false;
             }
@@ -1065,7 +1074,16 @@ function getFilteredEventsForDownload(minRating) {
 
         // Search filter
         if (searchTerm) {
-            const haystack = (event.description || '').toLowerCase();
+            const fields = [
+                event.title,
+                event.director,
+                event.oneLinerSummary,
+                event.description,
+            ];
+            const haystack = fields
+                .filter(Boolean)
+                .join(' ')
+                .toLowerCase();
             if (!haystack.includes(searchTerm)) {
                 return false;
             }


### PR DESCRIPTION
## Summary
- broaden search filter in frontend JS to include title, director, one-liner summaries and descriptions

## Testing
- `black --check src/ tests/ update_website_data.py pre_commit_checks.py`
- `pytest tests/ -v --tb=short -m "not live and not integration" --maxfail=5 -x` *(fails: AlienatedMajestyBooksScraper::test_all_book_club_events)*

------
https://chatgpt.com/codex/tasks/task_e_68681feb04248332a039ceb3f374fff9