### PR TITLE
Implement compact event cards with tab counts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,11 +29,11 @@
     <nav class="primary-nav">
         <div class="container">
             <ul class="nav-list">
-                <li><a href="#" class="nav-link active" data-view="today">Today</a></li>
-                <li><a href="#" class="nav-link" data-view="weekend">This Weekend</a></li>
-                <li><a href="#" class="nav-link" data-view="week">This Week</a></li>
-                <li><a href="#" class="nav-link" data-view="all">All Events</a></li>
-                <li><a href="#" class="nav-link" data-view="calendar">Calendar</a></li>
+                <li><a href="#" class="nav-link active" data-view="today" data-label="Today">Today</a></li>
+                <li><a href="#" class="nav-link" data-view="weekend" data-label="This Weekend">This Weekend</a></li>
+                <li><a href="#" class="nav-link" data-view="week" data-label="This Week">This Week</a></li>
+                <li><a href="#" class="nav-link" data-view="all" data-label="All Events">All Events</a></li>
+                <li><a href="#" class="nav-link" data-view="calendar" data-label="Calendar">Calendar</a></li>
                 <li class="nav-separator"></li>
                 <li><a href="#" class="nav-link nav-secondary" id="show-filters-link">Filters</a></li>
                 <li><a href="#" class="nav-link nav-secondary" id="download-link">Download</a></li>
@@ -112,11 +112,8 @@
         <div class="content-wrapper">
             <!-- Events List Section -->
             <section class="events-section" id="list-view">
-                <header class="section-header">
-                    <h2 id="events-heading" class="section-title">Today's Events</h2>
-                    <div class="section-meta">
-                        <span id="event-count" class="event-count"></span>
-                    </div>
+                <header class="section-header" id="events-header" style="display: none;">
+                    <h2 id="events-heading" class="section-title">Events</h2>
                 </header>
                 <div id="loading" class="loading">Loading event data...</div>
                 <div id="events-list" class="events-list"></div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -202,6 +202,7 @@ a:visited {
     letter-spacing: 0.1em;
     color: #333333;
     line-height: 3rem;
+    white-space: nowrap;
     transition: all 0.2s ease;
 }
 
@@ -262,8 +263,9 @@ a:visited {
 
 .event-card {
     border-bottom: 1px solid #e6e6e6;
-    padding: 2rem 0;
+    padding: 1rem 0;
     transition: all 0.2s ease;
+    cursor: pointer;
 }
 
 .event-card:last-child {
@@ -272,16 +274,20 @@ a:visited {
 
 .event-card:hover {
     background: #fafafa;
-    margin: 0 -1rem;
-    padding: 2rem 1rem;
+}
+
+.event-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 0.25rem;
 }
 
 .event-title {
     font-family: 'et-book', 'Georgia', serif;
-    font-size: 1.5rem;
+    font-size: 1.125rem;
     font-weight: 600;
     line-height: 1.3;
-    margin-bottom: 0.5rem;
     color: #000000;
 }
 
@@ -305,61 +311,35 @@ a:visited {
     outline-offset: 2px;
 }
 
-.event-time-venue {
-    font-family: 'Libre Franklin', 'Franklin Gothic', 'Helvetica Neue', sans-serif;
-    font-size: 0.6875rem; /* 11px */
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: #666666;
-    margin-bottom: 0.75rem;
-}
 
 .event-rating {
-    display: inline-block;
     font-family: 'et-book', 'Georgia', serif;
-    font-size: 1rem;
+    font-size: 0.875rem;
     font-weight: 600;
     color: #000000;
-    margin-bottom: 1rem;
+    margin-left: 0.5rem;
 }
 
 .event-summary {
     font-family: 'et-book', 'Georgia', serif;
     font-style: italic;
-    font-size: 1.125rem;
-    line-height: 1.5;
+    font-size: 0.875rem;
+    line-height: 1.4;
     color: #333333;
-    margin-bottom: 1rem;
+    margin: 0;
 }
 
 .event-metadata {
     font-family: 'Libre Franklin', 'Franklin Gothic', 'Helvetica Neue', sans-serif;
-    font-size: 0.875rem;
+    font-size: 0.75rem;
     color: #666666;
-    margin-bottom: 1rem;
+    margin-bottom: 0.25rem;
 }
 
-.read-review-btn {
-    font-family: 'Libre Franklin', 'Franklin Gothic', 'Helvetica Neue', sans-serif;
-    font-size: 0.875rem;
-    font-weight: 500;
-    background: transparent;
-    border: 1px solid #000000;
-    padding: 0.5rem 1.25rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    color: #000000;
-}
-
-.read-review-btn:hover {
-    background: #000000;
-    color: #ffffff;
-}
 
 .review-content {
-    margin-top: 1.5rem;
-    padding-top: 1.5rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
     border-top: 1px solid #e6e6e6;
 }
 
@@ -1036,8 +1016,7 @@ a:visited {
     
     .primary-nav,
     .filter-sidebar,
-    .sidebar-actions,
-    .read-review-btn {
+    .sidebar-actions {
         display: none;
     }
     


### PR DESCRIPTION
## Summary
- streamline list view layout for compact event cards
- show event counts in the active navigation tab
- update card markup and styles for three-line display
- hide the list header when viewing today's events

## Testing
- `python pre_commit_checks.py --check-only` *(fails: black formatting and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68686adbf3648332b7645c05692468e3