### PR TITLE
chore(ci): disable Claude Code Review workflow in favor of the LLM Council

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,17 @@
 name: Claude Code Review
 
+# Disabled: the LLM Council (pr-validation.yml) is now the code-review gate.
+# Left manual-only so it can be re-enabled by restoring the pull_request trigger below.
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize, ready_for_review, reopened]
+  #   # Optional: Only run on specific file changes
+  #   # paths:
+  #   #   - "src/**/*.ts"
+  #   #   - "src/**/*.tsx"
+  #   #   - "src/**/*.js"
+  #   #   - "src/**/*.jsx"
 
 jobs:
   claude-review:


### PR DESCRIPTION
The LLM Council (`pr-validation.yml`) is now the code-review gate for this repo, so the standalone Claude Code Review workflow no longer needs to run automatically on every PR.

This switches `claude-code-review.yml` to `workflow_dispatch`-only. The `pull_request` trigger is preserved (commented out) so it can be re-enabled in one edit if needed.

Note: this disable already exists on the `feat/ishida-dance-company` branch (commit 6967184) but never landed on `main`, so `main` still triggers Claude review on PRs. This PR brings the change to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)