### PR TITLE
Fix daily refresh + harden ICS feed + switch Haiku→OpenRouter (deepseek-v4-flash)

### DIFF
--- a/.github/workflows/daily-calendar-update.yml
+++ b/.github/workflows/daily-calendar-update.yml
@@ -43,10 +43,13 @@ jobs:
       - name: Run daily incremental update
         env:
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          # OpenRouter is the preferred LLM provider (cheaper); Anthropic stays
+          # as an automatic fallback when OPENROUTER_API_KEY is unset.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          echo "Running daily incremental update (7-day look-ahead)"
-          python update_website_data.py --days 7 --validate
+          echo "Running daily incremental update (~2-week recurring horizon)"
+          python update_website_data.py --test-week --validate
 
       - name: Verify update results
         run: |

--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Run weekly incremental update
         env:
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          # OpenRouter is the preferred LLM provider (cheaper); Anthropic stays
+          # as an automatic fallback when OPENROUTER_API_KEY is unset.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           echo "Running weekly incremental update"

--- a/config/master_config.yaml
+++ b/config/master_config.yaml
@@ -16,6 +16,13 @@ validation:
   error_on_missing_required_on_publish: true
   error_on_mismatched_dates_times_length: true
 
+# LLM provider/model selection. OpenRouter is preferred (cheaper) when
+# OPENROUTER_API_KEY is set; Anthropic Claude is the automatic fallback.
+# Override the model per-run with env OPENROUTER_MODEL / ANTHROPIC_MODEL.
+llm:
+  openrouter_model: deepseek/deepseek-v4-flash
+  anthropic_model: claude-haiku-4-5-20251001
+
 ontology:
   labels:
     - movie

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -448,6 +448,29 @@ def build_site(out_dir: Path, docs_dir: Path, generators: list[dict]) -> set[str
     return parity_check(docs_dir, out_dir, warned)
 
 
+_REQUIRED_FEEDS = {"calendar.ics": 1, "top-picks.ics": 0}  # filename -> min VEVENTs
+
+
+def assert_required_feeds(out_dir: Path) -> list[str]:
+    """Return problems with the published .ics feeds (empty list == healthy).
+
+    ``calendar.ics`` is the Apple Calendar webcal source and must never ship
+    missing or empty. VEVENTs are counted from the raw bytes — build_ics_feed
+    owns iCalendar parsing/validity; here we only assert the feed reached out/.
+    ``top-picks.ics`` may legitimately be empty (a quiet rating->=8 week).
+    """
+    problems: list[str] = []
+    for name, min_vevents in _REQUIRED_FEEDS.items():
+        path = out_dir / name
+        if not path.is_file():
+            problems.append(f"{name}: MISSING from {out_dir}")
+            continue
+        count = path.read_bytes().count(b"BEGIN:VEVENT")
+        if count < min_vevents:
+            problems.append(f"{name}: {count} VEVENT(s), need >= {min_vevents}")
+    return problems
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
@@ -474,7 +497,17 @@ def main(argv: list[str] | None = None) -> int:
     docs_dir = docs_dir.resolve()
 
     build_site(out_dir, docs_dir, _generators())
-    # Always exit 0 — this is a build tool; the parity report is the signal.
+
+    # The .ics feeds are the Apple Calendar webcal source: a crashed or empty
+    # build_ics_feed must FAIL the build so deploy-pages skips publishing and
+    # gh-pages keeps the last good feed — rather than silently shipping a dead
+    # calendar. Other generators stay best-effort (the parity report is their
+    # signal); only the feeds are a hard gate.
+    problems = assert_required_feeds(out_dir)
+    if problems:
+        for problem in problems:
+            print(f"[build_site] ERROR required feed: {problem}")
+        return 1
     return 0
 
 

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -375,6 +375,16 @@ class ConfigLoader:
         """
         return self._config.get("distribution", {})
 
+    def get_llm_config(self) -> Dict[str, Any]:
+        """
+        Get LLM provider/model configuration (default model per provider).
+
+        Returns:
+            LLM configuration dictionary (e.g. ``openrouter_model``,
+            ``anthropic_model``). Empty dict if not set.
+        """
+        return self._config.get("llm", {})
+
     def get_buttondown_endpoint(self) -> str:
         """
         Get Buttondown mailing-list endpoint URL.

--- a/src/enrichment_layer.py
+++ b/src/enrichment_layer.py
@@ -519,8 +519,9 @@ Output JSON format:
             if result:
                 return result
 
-        # Fall back to direct Anthropic call
-        if self.llm.anthropic:
+        # Fall back to the configured LLM provider (OpenRouter or Anthropic);
+        # _call_anthropic_json routes through the provider-agnostic _chat.
+        if self.llm.provider:
             return self.llm._call_anthropic_json(prompt, temperature)
 
         return None

--- a/src/llm_service.py
+++ b/src/llm_service.py
@@ -81,6 +81,49 @@ _VALIDATION_SYSTEM_PROMPT = (
     "JSON shape — no preamble."
 )
 
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+DEFAULT_OPENROUTER_MODEL = "deepseek/deepseek-v4-flash"
+DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _llm_cfg(key: str, default: str) -> str:
+    """Read the ``llm`` block of master_config.yaml, guarded.
+
+    Returns the configured value, or ``default`` when the config can't be
+    loaded — keeps LLMService importable in minimal/test environments.
+    """
+    try:
+        from src.config_loader import ConfigLoader
+
+        return ConfigLoader().get_llm_config().get(key) or default
+    except Exception:
+        return default
+
+
+def resolve_provider_model():
+    """Pick the LLM provider and model for the Haiku-tier calls.
+
+    OpenRouter is preferred (cheaper); Anthropic Claude is the automatic
+    fallback when ``OPENROUTER_API_KEY`` is unset. The model id is resolved
+    from the environment first (``OPENROUTER_MODEL`` / ``ANTHROPIC_MODEL``),
+    then ``config/master_config.yaml``'s ``llm`` block, then a built-in
+    default — never a bare hardcode that can silently go stale (a retired
+    ``google/gemini-2.5-flash`` id is exactly what broke CI before).
+
+    Returns ``(provider, model)`` or ``(None, None)`` when no key is set.
+    """
+    if os.getenv("OPENROUTER_API_KEY"):
+        model = os.getenv("OPENROUTER_MODEL") or _llm_cfg(
+            "openrouter_model", DEFAULT_OPENROUTER_MODEL
+        )
+        return "openrouter", model
+    if os.getenv("ANTHROPIC_API_KEY"):
+        model = os.getenv("ANTHROPIC_MODEL") or _llm_cfg(
+            "anthropic_model", DEFAULT_ANTHROPIC_MODEL
+        )
+        return "anthropic", model
+    return None, None
+
 
 class LLMService:
     """Centralized service for all LLM-powered data extraction and validation.
@@ -96,24 +139,18 @@ class LLMService:
         self.perplexity_api_key = os.getenv("PERPLEXITY_API_KEY")
         self.perplexity_base_url = "https://api.perplexity.ai"
 
-        if self.anthropic_api_key:
-            self.provider = "anthropic"
-            self.anthropic = anthropic.Anthropic(api_key=self.anthropic_api_key)
-            self.openai = None
-            self.model = "claude-haiku-4-5-20251001"
-        elif self.openrouter_api_key:
-            self.provider = "openrouter"
-            self.anthropic = None
+        # OpenRouter preferred (cheaper) > Anthropic fallback. The model id is
+        # config/env-driven (see resolve_provider_model) so it can't go stale.
+        self.provider, self.model = resolve_provider_model()
+        self.anthropic = None
+        self.openai = None
+        if self.provider == "openrouter":
             self.openai = OpenAI(
-                base_url="https://openrouter.ai/api/v1",
+                base_url=OPENROUTER_BASE_URL,
                 api_key=self.openrouter_api_key,
             )
-            self.model = "google/gemini-2.5-flash"
-        else:
-            self.provider = None
-            self.anthropic = None
-            self.openai = None
-            self.model = None
+        elif self.provider == "anthropic":
+            self.anthropic = anthropic.Anthropic(api_key=self.anthropic_api_key)
 
         self.extraction_cache = {}
         self.validation_cache = {}

--- a/src/summary_generator.py
+++ b/src/summary_generator.py
@@ -62,26 +62,29 @@ class SummaryGenerator:
     def __init__(self):
         self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
         self.openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
-        if not self.anthropic_api_key and not self.openrouter_api_key:
+
+        # OpenRouter preferred (cheaper) > Anthropic fallback. Provider + model
+        # come from the single source of truth in llm_service so the model id is
+        # config/env-driven (never a bare hardcode that can silently go stale).
+        from src.llm_service import OPENROUTER_BASE_URL, resolve_provider_model
+
+        self.provider, self.model = resolve_provider_model()
+        if self.provider is None:
             raise ValueError(
-                "Neither ANTHROPIC_API_KEY nor OPENROUTER_API_KEY is set; "
+                "Neither OPENROUTER_API_KEY nor ANTHROPIC_API_KEY is set; "
                 "at least one is required for summary generation."
             )
 
-        if self.anthropic_api_key:
-            self.provider = "anthropic"
-            self.client = anthropic.Anthropic(api_key=self.anthropic_api_key)
-            self.model = "claude-haiku-4-5-20251001"
-        else:
+        if self.provider == "openrouter":
             # Late import so tests without the openai package don't fail.
             from openai import OpenAI
 
-            self.provider = "openrouter"
             self.client = OpenAI(
-                base_url="https://openrouter.ai/api/v1",
+                base_url=OPENROUTER_BASE_URL,
                 api_key=self.openrouter_api_key,
             )
-            self.model = "google/gemini-2.5-flash"
+        else:
+            self.client = anthropic.Anthropic(api_key=self.anthropic_api_key)
 
         self.summary_cache = {}
         self._load_cache()

--- a/src/validation_service.py
+++ b/src/validation_service.py
@@ -171,11 +171,11 @@ class EventValidationService:
     def validate_event_content_with_llm(self, event: Dict) -> ValidationResult:
         """Use LLM to validate event content quality"""
         try:
-            if not self.llm_service.anthropic_api_key:
+            if self.llm_service.provider is None:
                 return ValidationResult(
                     passed=True,
                     level=ValidationLevel.INFO,
-                    message="LLM validation skipped (no API key)",
+                    message="LLM validation skipped (no LLM provider)",
                     event_data=event,
                 )
 
@@ -210,21 +210,30 @@ class EventValidationService:
             }}
             """
 
-            # Get LLM validation - use anthropic client directly.
-            # Use the model the LLMService configured for its active provider
-            # (claude-haiku-4-5 on Anthropic) instead of a hardcoded id; the
-            # previous "google/gemini-2.5-flash" 404'd against the Anthropic
-            # client, silently disabling all content validation in CI.
-            response = self.llm_service.anthropic.messages.create(
-                model=self.llm_service.model,
+            # Route through LLMService._chat so validation works on whichever
+            # provider is active (OpenRouter deepseek-v4-flash by default, or
+            # Anthropic Claude as fallback) — not hardwired to the Anthropic SDK.
+            response = self.llm_service._chat(
+                "You are a strict validator of cultural-event data. "
+                "Respond with JSON only.",
+                prompt,
                 max_tokens=200,
                 temperature=0.1,
-                messages=[{"role": "user", "content": prompt}],
             )
-            response = response.content[0].text.strip()
+            if not response:
+                return ValidationResult(
+                    passed=True,
+                    level=ValidationLevel.INFO,
+                    message="LLM validation skipped (no LLM response)",
+                    event_data=event,
+                )
 
-            # Parse response
+            # Parse response (tolerate code fences / preamble around the JSON)
             try:
+                json_start = response.find("{")
+                json_end = response.rfind("}") + 1
+                if json_start != -1 and json_end > json_start:
+                    response = response[json_start:json_end]
                 validation_data = json.loads(response)
                 is_valid = validation_data.get("is_valid", False)
                 confidence = validation_data.get("confidence", 0.0)

--- a/tests/test_ballet_dance_review.py
+++ b/tests/test_ballet_dance_review.py
@@ -136,7 +136,11 @@ def _make_processor(
     """Build an EventProcessor isolated from docs/data.json and the network."""
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
     if with_summary_generator:
+        # Pin the Anthropic provider so summary_generator.client exposes the
+        # `.messages` shape these tests patch. OpenRouter is now the default
+        # provider, so its key must be cleared to make the choice deterministic.
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-not-used")
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     else:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setattr(EventProcessor, "_load_existing_data", lambda self: None)

--- a/tests/test_build_site.py
+++ b/tests/test_build_site.py
@@ -110,9 +110,44 @@ def test_restore_brings_back_files_deleted_by_a_generator(
     assert missing == set()
 
 
-def test_main_exits_zero_even_with_missing_docs(tmp_path: Path, monkeypatch):
+def _write_ics(path: Path, n_vevents: int) -> None:
+    """Write a minimal iCalendar file containing ``n_vevents`` VEVENTs."""
+    body = b"BEGIN:VCALENDAR\r\n"
+    body += b"BEGIN:VEVENT\r\nSUMMARY:x\r\nEND:VEVENT\r\n" * n_vevents
+    body += b"END:VCALENDAR\r\n"
+    path.write_bytes(body)
+
+
+def test_assert_required_feeds_healthy(tmp_path: Path):
+    out = tmp_path / "_site"
+    out.mkdir()
+    _write_ics(out / "calendar.ics", 5)
+    _write_ics(out / "top-picks.ics", 0)  # top-picks may legitimately be empty
+    assert bs.assert_required_feeds(out) == []
+
+
+def test_assert_required_feeds_missing_calendar_is_a_problem(tmp_path: Path):
+    out = tmp_path / "_site"
+    out.mkdir()
+    _write_ics(out / "top-picks.ics", 2)
+    problems = bs.assert_required_feeds(out)
+    assert any("calendar.ics" in p and "MISSING" in p for p in problems)
+
+
+def test_assert_required_feeds_empty_calendar_is_a_problem(tmp_path: Path):
+    out = tmp_path / "_site"
+    out.mkdir()
+    _write_ics(out / "calendar.ics", 0)  # valid iCal but zero events == dead feed
+    _write_ics(out / "top-picks.ics", 0)
+    problems = bs.assert_required_feeds(out)
+    assert any("calendar.ics" in p and "need >= 1" in p for p in problems)
+
+
+def test_main_fails_when_required_feeds_missing(tmp_path: Path, monkeypatch):
+    # No generators + a missing docs dir means no .ics feeds are produced, so
+    # main() must FAIL (non-zero) rather than ship a deploy without a calendar.
     monkeypatch.setattr(bs, "_generators", lambda: [])
     rc = bs.main(
         ["--out", str(tmp_path / "_site"), "--docs-dir", str(tmp_path / "nope")]
     )
-    assert rc == 0
+    assert rc == 1

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,95 @@
+"""Provider/model resolution + provider-agnostic content validation.
+
+Covers the OpenRouter-preferred switch:
+
+* ``resolve_provider_model()`` picks OpenRouter (deepseek-v4-flash) when its
+  key is set, falls back to Anthropic Claude otherwise, and honours env
+  model overrides — never a bare hardcode that can silently go stale (the
+  retired ``google/gemini-2.5-flash`` id is what broke CI before).
+* :class:`EventValidationService` content validation runs through the
+  provider-agnostic ``LLMService._chat`` (not the Anthropic SDK directly), so
+  it works under OpenRouter where ``llm_service.anthropic`` is ``None``.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.llm_service import (
+    DEFAULT_ANTHROPIC_MODEL,
+    DEFAULT_OPENROUTER_MODEL,
+    LLMService,
+    resolve_provider_model,
+)
+from src.validation_service import EventValidationService
+
+
+def test_resolve_prefers_openrouter(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    monkeypatch.delenv("OPENROUTER_MODEL", raising=False)
+    provider, model = resolve_provider_model()
+    assert provider == "openrouter"
+    # Default comes from config/master_config.yaml's llm.openrouter_model.
+    assert model == DEFAULT_OPENROUTER_MODEL == "deepseek/deepseek-v4-flash"
+
+
+def test_resolve_falls_back_to_anthropic(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+    provider, model = resolve_provider_model()
+    assert provider == "anthropic"
+    assert model == DEFAULT_ANTHROPIC_MODEL
+
+
+def test_resolve_env_model_override_wins(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.setenv("OPENROUTER_MODEL", "deepseek/deepseek-v4-pro")
+    provider, model = resolve_provider_model()
+    assert provider == "openrouter"
+    assert model == "deepseek/deepseek-v4-pro"
+
+
+def test_resolve_no_keys_returns_none(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert resolve_provider_model() == (None, None)
+
+
+def test_llm_service_builds_openrouter_client(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    svc = LLMService()
+    assert svc.provider == "openrouter"
+    assert svc.model == "deepseek/deepseek-v4-flash"
+    assert svc.openai is not None
+    assert svc.anthropic is None
+
+
+def test_content_validation_uses_chat_not_anthropic_sdk():
+    """Validation must route through _chat so it works under OpenRouter."""
+    fake_llm = Mock()
+    fake_llm.provider = "openrouter"
+    fake_llm.anthropic = None  # the old SDK path would AttributeError on None
+    fake_llm._chat = Mock(
+        return_value=(
+            '{"is_valid": true, "confidence": 0.9, '
+            '"issues": [], "reasoning": "looks legit"}'
+        )
+    )
+
+    svc = EventValidationService(llm_service=fake_llm)
+    event = {
+        "title": "Test Concert",
+        "date": "2026-07-01",
+        "time": "19:30",
+        "venue": "Symphony",
+        "type": "concert",
+        "description": "A real evening of orchestral music. " * 5,
+    }
+    result = svc.validate_event_content_with_llm(event)
+
+    fake_llm._chat.assert_called_once()
+    assert result.passed is True
+    assert "validation passed" in result.message.lower()


### PR DESCRIPTION
## Why

The Apple Calendar `webcal://` feed (`calendar.ics` / `top-picks.ics`) was only staying fresh because of **manual** pipeline runs — the scheduled automation wasn't sustaining it. An audit traced this to three issues; two were already fixed on `main` by the 2026-06-03 commit (the gemini-404 in validation and the `austinSymphony` empty-events abort — the first scheduled weekly on that fixed code, 2026-06-06, passed). This PR fixes what remained, plus a robustness gap, plus a requested cost change.

## What

**1. Unbreak the daily job** (`fix(ci)`)
The Daily Incremental Update ran `update_website_data.py --days 7`, but argparse has no `--days` flag — every scheduled daily run since 2026-06-03 died with "unrecognized arguments" before scraping/committing (zero daily commits ever). Switched to the existing `--test-week` flag (~2-week recurring horizon; lighter than the weekly ~8-week run).

**2. Switch Haiku-tier LLM calls to OpenRouter** (`feat(llm)`)
HTML extraction, fail-fast content validation, and one-liner summaries now use OpenRouter `deepseek/deepseek-v4-flash` instead of Claude Haiku (~10–25× cheaper). Provider/model selection is centralized in `llm_service.resolve_provider_model()`:
- OpenRouter preferred when `OPENROUTER_API_KEY` is set; **Anthropic Claude is the automatic fallback**.
- Model id resolved from env (`OPENROUTER_MODEL` / `ANTHROPIC_MODEL`) → `master_config.yaml` `llm:` block → built-in default. **No more stale hardcoded model ids** (a retired `google/gemini-2.5-flash` is exactly what broke CI before).
- `validation_service` now routes through the provider-agnostic `_chat` (was hardwired to the Anthropic SDK); `enrichment_layer`'s post-Perplexity fallback gates on `provider`, not on the Anthropic client.
- Perplexity (ratings) and the Sonnet review-essay calls are intentionally unchanged.
- `OPENROUTER_API_KEY` (already a repo secret) is now passed to the daily + weekly workflows.

**3. Harden the ICS build** (`fix(build)`)
`build_site.py` was best-effort and always exited 0, so a crashed/empty `build_ics_feed` could silently ship a dead `calendar.ics` with green CI. Added `assert_required_feeds()`: `main()` now exits non-zero when `calendar.ics` is missing or has zero `VEVENT`s, so `deploy-pages` skips publishing and `gh-pages` keeps the last good feed.

## Verification

- `pytest -m "not live and not integration"` → **796 passed, 13 skipped**; `black --check` clean.
- Live OpenRouter smoke: `provider=openrouter`, `model=deepseek/deepseek-v4-flash`, real call returned `OK`.
- Feed gate against real `docs/data.json`: `calendar.ics` built with 299 VEVENTs → `assert_required_feeds` healthy; empty dir → flagged MISSING.
- New tests: provider resolution (OpenRouter-first, Anthropic fallback, env override, no-keys), validation-via-`_chat`, and `assert_required_feeds`.

## After merge

The next 11:00-UTC daily run should go green and commit `Daily incremental update - <date>`, triggering a successful `deploy-pages` — the definitive "stays fresh on its own" signal. (Client-side: Apple Calendar's own subscription refresh interval is the last hop the server can't control — recommend "every day".)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
