### PR TITLE
fix(venues): recover two venues that only failed in production

### DIFF
--- a/config/master_config.yaml
+++ b/config/master_config.yaml
@@ -1235,10 +1235,13 @@ web_llm_scrapers:
     default_time: "10:00"
 
   bullock:
+    # Serves 200 to a residential IP but 403s the GitHub runner, so the http
+    # mode worked locally and returned nothing in production. Datacenter-range
+    # blocking is invisible from a laptop; use the no-fetch path.
     base_url: "https://www.thestoryoftexas.com"
     venue_name: "Bullock"
     urls: ["/visit/exhibits"]
-    fetch: http
+    fetch: perplexity
     default_event_type: visual_arts
     default_time: "10:00"
 

--- a/src/scrapers/_web_llm_scraper.py
+++ b/src/scrapers/_web_llm_scraper.py
@@ -223,6 +223,27 @@ def _parse_human_date_range(text: str, today: Optional[date] = None) -> tuple:
     return start, end
 
 
+def _events_from_payload(data: Any) -> List[Dict]:
+    """Pull the event list out of an extraction payload.
+
+    The schema asks for ``{"events": [...]}`` and models mostly comply, but
+    they also rename it to whatever suits the page ("exhibitions", "shows").
+    Falls back to the first list-of-objects in the payload rather than
+    discarding a perfectly good extraction over the wrapper's name.
+    """
+    if not isinstance(data, dict):
+        return []
+
+    events = data.get("events")
+    if isinstance(events, list) and events:
+        return [e for e in events if isinstance(e, dict)]
+
+    for value in data.values():
+        if isinstance(value, list) and any(isinstance(e, dict) for e in value):
+            return [e for e in value if isinstance(e, dict)]
+    return []
+
+
 def _any_date_field(event: Dict[str, Any]) -> Any:
     """Last-resort search for whichever key the extractor put the dates in.
 
@@ -463,13 +484,22 @@ class WebLlmScraper(BaseScraper):
             # default 2000-token budget truncates the response mid-array.
             max_tokens=4000,
         )
+
+        # Read the payload whether or not the parse was declared a success.
+        # The usefulness check keys off the literal name "events", so a model
+        # that returned its array as "exhibitions" got the whole page thrown
+        # away with "No useful data extracted" - which is what silently emptied
+        # Flatbed Press in production while working locally.
+        events = _events_from_payload(result.get("data"))
+        if events:
+            return events
+
         if not result.get("success"):
             print(
                 f"  {self.venue_name}: extraction failed for {url}: "
                 f"{result.get('error', 'unknown error')}"
             )
-            return []
-        return result.get("data", {}).get("events", []) or []
+        return []
 
     def _perplexity_prompt(self) -> str:
         """Prompt for the no-fetch mode, built from the same config schema.

--- a/tests/test_web_llm_scraper.py
+++ b/tests/test_web_llm_scraper.py
@@ -17,6 +17,7 @@ from src.scrapers._web_llm_scraper import (
     _PIPELINE_DERIVED_FIELDS,
     WebLlmScraper,
     _as_list,
+    _events_from_payload,
     _normalize_date,
     _normalize_time,
     _split_date_range,
@@ -186,6 +187,28 @@ class TestNormalizeTime:
     def test_rejects_non_times(self, raw):
         """A date must never be read as a time - '2026-08-14' is not 20:00."""
         assert _normalize_time(raw) is None
+
+
+@pytest.mark.unit
+class TestEventsFromPayload:
+    def test_prefers_the_declared_key(self):
+        payload = {"events": [{"title": "A"}], "other": [{"title": "B"}]}
+        assert _events_from_payload(payload) == [{"title": "A"}]
+
+    def test_falls_back_to_a_renamed_array(self):
+        assert _events_from_payload({"exhibitions": [{"title": "A"}]}) == [{"title": "A"}]
+
+    def test_skips_arrays_of_scalars(self):
+        """A list of strings is not an event list."""
+        payload = {"tags": ["a", "b"], "shows": [{"title": "A"}]}
+        assert _events_from_payload(payload) == [{"title": "A"}]
+
+    @pytest.mark.parametrize("payload", [None, {}, [], "text", {"events": []}, {"events": None}])
+    def test_returns_empty_for_nothing_usable(self, payload):
+        assert _events_from_payload(payload) == []
+
+    def test_drops_non_dict_entries(self):
+        assert _events_from_payload({"events": [{"title": "A"}, "junk"]}) == [{"title": "A"}]
 
 
 @pytest.mark.unit
@@ -534,6 +557,25 @@ class TestScrapeEvents:
         scraper.llm_service = Mock()
         scraper.llm_service.provider = None
         assert scraper.scrape_events() == []
+
+    def test_accepts_a_renamed_top_level_array(self, monkeypatch):
+        """Models rename the wrapper to suit the page ("exhibitions").
+
+        The usefulness check keys off the literal name "events", so this used
+        to come back as "No useful data extracted" and lose the whole page.
+        """
+        scraper = _make()
+        monkeypatch.setattr(scraper, "_fetch_http", lambda url: "<body><main>x</main></body>")
+        scraper.llm_service = Mock()
+        scraper.llm_service.provider = "stub"
+        scraper.llm_service.extract_data.return_value = {
+            "success": False,
+            "error": "No useful data extracted - all fields are empty, null, or missing required data",
+            "data": {"exhibitions": [{"title": "Show", "dates": ["2026-08-14"]}]},
+        }
+        events = scraper.scrape_events()
+        assert len(events) == 1
+        assert events[0]["title"] == "Show"
 
     def test_failed_extraction_yields_no_events(self, monkeypatch):
         scraper = _make()


### PR DESCRIPTION
The first production run after #50 went green and picked up all 13 new venues, but two came back empty for reasons that don't reproduce on a laptop. Both were only findable because of the ⚠️ marker on zero-event venues added in #50.

## Flatbed Press — lost the page over the wrapper's name

```
FlatbedPress: extraction failed: No useful data extracted - all fields are empty, null, or missing required data
```

`_is_extraction_data_useful` keys off the literal top-level name `events`. The model had returned its array under a different name, so a perfectly good extraction was thrown away wholesale.

This is the same drift already handled for date fields, one level up — models rename the wrapper to suit the page (`exhibitions`, `shows`). Now reads the first list-of-objects in the payload, and reads it whether or not the parse was declared a success.

## The Bullock — 403s the GitHub runner only

```
Bullock: https://www.thestoryoftexas.com/visit/exhibits returned 403
```

Serves 200 to a residential IP, 403s the runner. Datacenter-range blocking, invisible from a laptop. Moved to the `perplexity` no-fetch path — the same escape hatch The Contemporary Austin and NowPlayingAustin both use, and both returned events in that same production run.

## Verification

Flatbed and Blanton still return 4 and 2 valid events locally. 979 tests passing, with new coverage for the renamed-wrapper case and `_events_from_payload`.

## Note on the remaining empties

Women & Their Work and MASS Gallery return 0 correctly — their listings are genuinely all past shows, confirmed by reading the pages. Ivester and Blanton are model nondeterminism: both extract correctly when the model returns the current show, and neither errors. Worth watching over a few scheduled runs rather than tuning blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiRjoaFnyMRWNXb2qmXYEX