### PR TITLE
feat(site): stop scoring what we cannot judge

### DIFF
--- a/.council/live-site.json
+++ b/.council/live-site.json
@@ -44,7 +44,7 @@
       "persona": "mobile-user",
       "dimension": "live-mobile",
       "verdict_contract": "pass-fail-abstain",
-      "model": { "openrouter_id": "qwen/qwen3.7-plus", "family": "qwen", "tier": "fast" },
+      "model": { "openrouter_id": "x-ai/grok-4.5", "family": "x-ai", "tier": "fast" },
       "persona_spec_path": "personas/council/mobile-user.json"
     }
   ],

--- a/.council/live-site.json
+++ b/.council/live-site.json
@@ -44,7 +44,7 @@
       "persona": "mobile-user",
       "dimension": "live-mobile",
       "verdict_contract": "pass-fail-abstain",
-      "model": { "openrouter_id": "xiaomi/mimo-v2.5", "family": "xiaomi", "tier": "fast" },
+      "model": { "openrouter_id": "qwen/qwen3.7-plus", "family": "qwen", "tier": "fast" },
       "persona_spec_path": "personas/council/mobile-user.json"
     }
   ],

--- a/.council/live-site.json
+++ b/.council/live-site.json
@@ -3,7 +3,7 @@
   "goal": "Culture Calendar live-site UX gate: the deployed site (served locally from docs/) must stay usable, comprehensive, and regression-free across logistics, review-reading, search, coverage/comprehensiveness, feature continuity, and mobile. Treat the structural ground truth in the context file as authoritative.",
   "maker": { "openrouter_id": "anthropic/claude-opus-4", "family": "anthropic" },
   "scope": {},
-  "_note": "Six UX lenses, each judged by a distinct non-Anthropic family for maximum diversity (Anthropic excluded as maker). No separate synthesis layer: deterministic per-feature regressions are caught by scripts/check_live_site.py (structural asserts in personas/live-site-specs/), and the council adds cross-family holistic judgment. Model slugs from the skill's cache/model-pool.json (2026-05-28); refresh + re-pick when the frontier moves. persona_spec_path is relative to the repo root.",
+  "_note": "Six UX lenses, each judged by a distinct non-Anthropic family for maximum diversity (Anthropic excluded as maker). No separate synthesis layer: deterministic per-feature regressions are caught by scripts/check_live_site.py (structural asserts in personas/live-site-specs/), and the council adds cross-family holistic judgment. Model slugs must exist on OpenRouter AND support tool use - the runner forces a tool call, so a model without it 404s and that juror silently drops out of the panel. Both google and xiaomi slugs had rotted this way (one was an image-only preview, the other deprecated), leaving the gate running 4/6 including a dead continuity-user, which is the lens that catches removed features. Verify with https://openrouter.ai/api/v1/models before changing. persona_spec_path is relative to the repo root.",
   "panel": [
     {
       "persona": "logistics-user",
@@ -37,14 +37,14 @@
       "persona": "continuity-user",
       "dimension": "live-continuity",
       "verdict_contract": "pass-fail-abstain",
-      "model": { "openrouter_id": "google/gemini-3-pro-image-preview", "family": "google", "tier": "fast" },
+      "model": { "openrouter_id": "google/gemini-3.6-flash", "family": "google", "tier": "fast" },
       "persona_spec_path": "personas/council/continuity-user.json"
     },
     {
       "persona": "mobile-user",
       "dimension": "live-mobile",
       "verdict_contract": "pass-fail-abstain",
-      "model": { "openrouter_id": "xiaomi/mimo-v2-omni", "family": "xiaomi", "tier": "fast" },
+      "model": { "openrouter_id": "xiaomi/mimo-v2.5", "family": "xiaomi", "tier": "fast" },
       "persona_spec_path": "personas/council/mobile-user.json"
     }
   ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,32 @@ Static JSON loading is used for season-based venues (Symphony, Early Music, La F
 - **Debug scraper failures**: run with `--validate`; check if site structure changed (most common cause); review LLM prompts for smart scrapers; inspect enrichment telemetry.
 - **Modify schema**: edit template in master_config.yaml; update scraper; update enrichment prompts; adjust `update_website_data.py:build_event_from_template()`; update tests.
 
+### Rating policy — only film is scored
+
+`rating` (0–10) is generated for every event but **displayed for film only**. The site's single source of truth is `SCORED_CATEGORIES` in `docs/script.js`.
+
+Measured across the published corpus, by share of reviews where the model explicitly declines to judge:
+
+| category | declines | mean | range |
+|---|---|---|---|
+| movie | 19% | 5.9 | 0–10 |
+| dance | 32% | 4.0 | 0–5 |
+| visual_arts | 56% | 3.4 | 1–7 |
+| opera | 58% | 5.2 | 0–9 |
+| concert | 73% | 3.5 | 0–8 |
+
+Outside film the number tracks how much source material the extractor found, not quality — a gallery show described only by title and venue scores low regardless of the work. A calendar's job is to surface what is on, not to arbitrate quality for work that is unique and unreviewed.
+
+Consequences to preserve when touching the UI:
+- No badge for unscored categories, and **no fabricated fallback** (the venue-average / flat-5 `derivedRating` path is gated on `isScored`).
+- Unscored events sort by `urgencyDate` — closing date for a running show, opening date otherwise — never by rating.
+- "Top picks" is a ranking claim; the heading becomes "On this week" when nothing in the list is scored, and the rank counter is suppressed.
+- Reviews and one-liners that decline to judge (`NON_JUDGEMENT_RE`) are not rendered as criticism.
+
+Adding a category to `SCORED_CATEGORIES` needs evidence that its scores actually discriminate. `tests/test_scoreless_categories.py` pins all of the above.
+
+Still open: ratings continue to drive the weekly tipsheet's picks, which has the same problem for non-film events.
+
 ### Classical refresh pipeline
 
 Season-based classical/ballet venues (Austin Symphony, Early Music Austin, La Follia, Austin Chamber Music, Austin Opera, Ballet Austin) ship as static JSON in `docs/classical_data.json` + `docs/ballet_data.json`, not via per-event scrapers. `scripts/refresh_classical_data.py` is the LLM-driven monthly refresh.

--- a/config/feature-inventory.json
+++ b/config/feature-inventory.json
@@ -516,7 +516,6 @@
     "selector": "#event-search",
     "since_commit": "task-date-search",
     "smoke_assertion": "contains_text:parseDateQuery@/script.js"
-  }
   },
   {
     "id": "category-filter-chips",
@@ -559,5 +558,47 @@
     "selector": ".filter-bar",
     "since_commit": "T8.5",
     "smoke_assertion": "contains_text:position: sticky@/styles.css"
+  },
+  {
+    "id": "scoreless-categories",
+    "name": "Only film carries a 0-10 score; other categories show none",
+    "selector": ".event-card-unscored",
+    "since_commit": "scoreless-categories",
+    "smoke_assertion": "contains_text:SCORED_CATEGORIES@/script.js"
+  },
+  {
+    "id": "unscored-card-face",
+    "name": "No-score card face: no rating badge, accent rule, full-width title",
+    "selector": ".event-card-unscored .event-header",
+    "since_commit": "scoreless-categories",
+    "smoke_assertion": "contains_text:.event-card-unscored .event-header@/styles.css"
+  },
+  {
+    "id": "exhibition-run-note",
+    "name": "Exhibition run note (Through / Closes date) in place of a score",
+    "selector": ".event-run-note",
+    "since_commit": "scoreless-categories",
+    "smoke_assertion": "contains_text:event-run-note@/styles.css"
+  },
+  {
+    "id": "urgency-ordering",
+    "name": "Unscored categories order by urgency (closing soon first)",
+    "selector": ".event-card-unscored",
+    "since_commit": "scoreless-categories",
+    "smoke_assertion": "contains_text:function urgencyDate@/script.js"
+  },
+  {
+    "id": "picks-heading-adapts",
+    "name": "Picks heading drops the ranking claim for unranked lists",
+    "selector": ".picks-heading",
+    "since_commit": "scoreless-categories",
+    "smoke_assertion": "contains_text:ON THIS WEEK@/script.js"
+  },
+  {
+    "id": "non-judgement-suppression",
+    "name": "Reviews that decline to judge are not rendered as criticism",
+    "selector": ".event-review",
+    "since_commit": "scoreless-categories",
+    "smoke_assertion": "contains_text:NON_JUDGEMENT_RE@/script.js"
   }
 ]

--- a/docs/script.js
+++ b/docs/script.js
@@ -946,6 +946,11 @@
           description: ev.description || "",
           one_liner: ev.one_liner_summary || "",
           review_confidence: (ev.review_confidence || "unknown").toLowerCase(),
+          end_date: ev.end_date || "",
+          artist: ev.artist || "",
+          artists: ev.artists || [],
+          medium: ev.medium || "",
+          series: ev.series || "",
           director: ev.director || "",
           composers: ev.composers || [],
           author: ev.author || "",
@@ -973,7 +978,20 @@
     });
     var result = order.map(function (k) { return byTitle[k]; });
     result.forEach(function (ev) { ev.showings = dedupeShowings(ev.showings); });
-    result.sort(function (a, b) { return b.rating - a.rating || a.title.localeCompare(b.title); });
+
+    /* Scored and unscored events are ordered by different keys, because they
+       have different ones worth ordering by. Film sorts best-first; everything
+       else sorts by urgency (see urgencyDate). In a mixed list the scored ones
+       lead - selecting a single scoreless category yields a homogeneous list,
+       so that view is purely chronological with no special-casing. */
+    var today = todayISO();
+    result.sort(function (a, b) {
+      var aScored = isScored(a), bScored = isScored(b);
+      if (aScored !== bScored) return aScored ? -1 : 1;
+      if (aScored) return b.rating - a.rating || a.title.localeCompare(b.title);
+      var ua = urgencyDate(a, today), ub = urgencyDate(b, today);
+      return ua < ub ? -1 : ua > ub ? 1 : a.title.localeCompare(b.title);
+    });
     return result;
   }
 
@@ -988,6 +1006,47 @@
   }
 
   function ratingClass(r) { return r >= 8 ? "high" : r >= 5 ? "mid" : "low"; }
+
+  /* Which categories get a 0-10 score at all.
+
+     Film is the only one where the number carries signal. Measured across the
+     published corpus: film reviews decline to judge 19% of the time and the
+     scores spread the full 0-10, whereas concert declines 73% of the time and
+     visual arts 56%, both clustering flat around 3.4. In those categories the
+     model is scoring how much material it could find, not how good the work
+     is - a gallery show described only by title and venue scores low no matter
+     what is on the walls.
+
+     A calendar's job here is to surface what is on, not to arbitrate quality
+     for work that is by definition unique and unreviewed. So we show no score
+     rather than a confident-looking wrong one. */
+  var SCORED_CATEGORIES = { movie: true };
+
+  function isScored(ev) {
+    return SCORED_CATEGORIES[String(ev && ev.type || "").toLowerCase()] === true;
+  }
+
+  /* Local calendar date as YYYY-MM-DD, so it compares directly against the
+     ISO date strings in the data. Deliberately local rather than UTC: "is this
+     show still up today" is a question about the reader's day in Austin. */
+  function todayISO(now) {
+    var d = now || new Date();
+    var m = d.getMonth() + 1, day = d.getDate();
+    return d.getFullYear() + "-" + (m < 10 ? "0" + m : m) + "-" + (day < 10 ? "0" + day : day);
+  }
+
+  /* The date that decides where an unscored event sorts.
+
+     For a show already open, that is its closing date - a months-long
+     exhibition is urgent when it is about to come down, not when it opened.
+     For one not yet open, it is the opening date. Both ascending, so the list
+     reads "what you are about to miss, then what is coming". */
+  function urgencyDate(ev, today) {
+    var first = ev.showings && ev.showings[0] ? ev.showings[0].date : "";
+    var end = ev.end_date || "";
+    if (end && first && first <= today) return end;
+    return first || end || "9999-12-31";
+  }
 
   /* task-T8.2: derived rating for ungraded events (rating <= 0).
      Uses the venue's average rating when available, falling back to 5.
@@ -1307,6 +1366,46 @@
     return safe;
   }
 
+  /* Phrases where the model is telling us it had nothing to go on.
+
+     A gallery listing usually gives a title, a venue and a date, so the critic
+     prompt produces paragraphs like "There is not enough evidence in the
+     supplied material to judge composition, materials, technique, or
+     installation with confidence." That is an honest answer to a question we
+     should not have asked, and rendering it under a heading like "Artistic
+     Merit" presents an absence of information as a critical finding. Drop
+     those sections and keep whatever actually describes the show.
+
+     What these paragraphs have in common is that they discuss the *record* -
+     the supplied material, the available information - rather than the work,
+     so that is what we match on rather than trying to enumerate phrasings. */
+  var NON_JUDGEMENT_RE = new RegExp([
+    // Talking about the source material instead of the art.
+    "available (record|information|material|evidence|documentation|sources)",
+    "supplied material",
+    "information (provided|available|given)",
+    "(provided|public|thin|the) (public )?(sources|record)\\b",
+    "sources (here|do not|don't|are)",
+    // Explicit refusals.
+    "not enough (evidence|information)",
+    "insufficient (evidence|information)",
+    "cannot (be |fairly )?(assess|judge|evaluat|credit|verify)",
+    "can(not|'t) be (assessed|judged|evaluated)",
+    "unable to (assess|judge|evaluat)",
+    "impossible to (assess|judge|evaluat)",
+    "no basis (for|to)",
+    "no (exhibition-specific |further |public )?(evidence|record|detail)",
+    // Absence-of-facts statements.
+    "(is|are) not (described|documented|identified|specified)",
+    "no (artist|medium|series|works|visual description|checklist)",
+    "remains undocumented",
+    "without (more|additional|further) (detail|information)"
+  ].join("|"), "i");
+
+  function isNonJudgement(text) {
+    return NON_JUDGEMENT_RE.test(String(text || ""));
+  }
+
   function parseReview(html) {
     if (!html) return { rating: "", sections: [], flat: "" };
     var doc = new DOMParser().parseFromString("<div>" + html + "</div>", "text/html");
@@ -1388,8 +1487,11 @@
       seenLabels[s.label] = true;
       return true;
     });
+    // Drop the sections where the model reported having nothing to judge.
+    var declined = sections.filter(function (s) { return isNonJudgement(s.body); }).length;
+    sections = sections.filter(function (s) { return !isNonJudgement(s.body); });
     var flat = sections.map(function (s) { return s.body; }).join("\n\n");
-    return { rating: rating, sections: sections, flat: flat };
+    return { rating: rating, sections: sections, flat: flat, declined: declined };
   }
 
   function formatDate(str) {
@@ -1659,9 +1761,12 @@
     var filtered = filterEvents(allEvents);
     var grouped = groupEvents(filtered);
     var venueAvgs = computeVenueAverages(grouped);
-    // task-T8.2: apply derived ratings so no event shows "-"
+    /* task-T8.2: derive a rating for ungraded events so no card shows "-".
+       Now only for categories that are scored at all - inventing a venue
+       average for a gallery show would put a fabricated number in the exact
+       place a real judgement goes. */
     grouped.forEach(function (ev) {
-      if (typeof ev.rating !== "number" || ev.rating <= 0) {
+      if (isScored(ev) && (typeof ev.rating !== "number" || ev.rating <= 0)) {
         ev._derivedRating = derivedRating(ev, venueAvgs);
       }
     });
@@ -2008,6 +2113,15 @@
     lastRenderedPicks = (picks || []).map(function (item) {
       return item && item.ev ? item.ev : item;
     });
+    /* "Top picks" is a ranking claim. When nothing in the list is scored - as
+       when the reader has filtered to Visual Arts - there is no ranking behind
+       it, only urgency order, so the heading says what the list actually is
+       rather than implying a judgement we did not make. */
+    var picksHeading = document.querySelector("#picks .picks-heading");
+    if (picksHeading) {
+      var anyScored = lastRenderedPicks.some(isScored);
+      picksHeading.textContent = anyScored ? "TOP PICKS OF THE WEEK" : "ON THIS WEEK";
+    }
     if (picks.length === 0) {
       var empty = document.createElement("li");
       empty.className = "empty-state";
@@ -2133,9 +2247,80 @@
     });
   }
 
+  /* Add the 0-10 badge, but only where the number means anything.
+
+     Unscored categories previously got a *fabricated* one: the venue's average
+     rating, or a flat 5, so that every card had a badge and the list stayed
+     sortable. That is the worst version - a made-up number presented in the
+     same visual language as a real judgement. */
+  function appendRatingBadge(header, ev) {
+    if (!isScored(ev)) return null;
+    var badge = document.createElement("span");
+    var displayRating = ev.rating > 0 ? ev.rating : (ev._derivedRating || 5);
+    badge.className = "event-rating-badge rating-" + ratingClass(displayRating);
+    badge.textContent = displayRating + " / 10";
+    badge.setAttribute("aria-label", "rated " + displayRating + " out of 10");
+    header.appendChild(badge);
+    return badge;
+  }
+
+  /* Subtitle line. Scored events lead with venue and showtime; unscored ones
+     lead with the facts that actually help you decide to go - who made it,
+     in what medium, and how long you have left to see it. */
+  function buildSubtitle(ev, opts) {
+    opts = opts || {};
+    var sub = document.createElement("div");
+    sub.className = "event-subtitle";
+    var parts = [];
+    var venueLabel = ev.venue_display_name || ev.venue;
+    if (venueLabel) parts.push(venueLabel);
+    parts.push(CATEGORY_LABELS[ev.type] || (ev.type || "").replace(/_/g, " "));
+    (opts.extras || []).forEach(function (x) { if (x) parts.push(x); });
+
+    if (!isScored(ev)) {
+      var who = ev.artist || (ev.artists && ev.artists.length ? ev.artists.join(", ") : "");
+      if (who) parts.push(who);
+      if (ev.medium) parts.push(ev.medium);
+    }
+    var next = ev.showings && ev.showings[0];
+    if (opts.includeNext && next) {
+      parts.push(formatDate(next.date) + (next.time ? " · " + formatTime(next.time) : ""));
+    }
+    sub.textContent = parts.join(" · ");
+
+    var run = runNoteFor(ev);
+    if (run) {
+      var note = document.createElement("span");
+      note.className = "event-run-note" + (run.closingSoon ? " is-closing-soon" : "");
+      note.textContent = run.text;
+      sub.appendChild(document.createTextNode(" "));
+      sub.appendChild(note);
+    }
+    return sub;
+  }
+
+  /* "Closes 12 Sep" for a run that is currently on, flagged when it is nearly
+     over. This is the replacement for a score: for an exhibition, how long you
+     have left is the genuinely useful, genuinely knowable fact. */
+  var CLOSING_SOON_DAYS = 14;
+
+  function runNoteFor(ev) {
+    if (isScored(ev) || !ev.end_date) return null;
+    var today = todayISO();
+    if (ev.end_date < today) return null;
+    var first = ev.showings && ev.showings[0] ? ev.showings[0].date : "";
+    if (first && first > today) return { text: "Through " + formatDate(ev.end_date), closingSoon: false };
+    var days = Math.round((new Date(ev.end_date) - new Date(today)) / 86400000);
+    return {
+      text: days <= CLOSING_SOON_DAYS ? "Closes " + formatDate(ev.end_date) : "Through " + formatDate(ev.end_date),
+      closingSoon: days <= CLOSING_SOON_DAYS
+    };
+  }
+
   function buildPickCard(ev, reason) {
     var card = document.createElement("li");
     card.className = "event-card pick-card";
+    if (!isScored(ev)) card.classList.add("event-card-unscored");
     if (ev.showings && ev.showings[0]) {
       card.dataset.firstDate = ev.showings[0].date;
     }
@@ -2143,12 +2328,7 @@
     var header = document.createElement("div");
     header.className = "event-header";
 
-    var badge = document.createElement("span");
-    var displayRating = ev.rating > 0 ? ev.rating : (ev._derivedRating || 5);
-    badge.className = "event-rating-badge rating-" + ratingClass(displayRating);
-    badge.textContent = displayRating + " / 10";
-    badge.setAttribute("aria-label", "rated " + displayRating + " out of 10");
-    header.appendChild(badge);
+    appendRatingBadge(header, ev);
 
     var col = document.createElement("div");
     col.className = "event-title-col";
@@ -2164,15 +2344,7 @@
     } else { title.textContent = ev.title; }
     col.appendChild(title);
 
-    var sub = document.createElement("div");
-    sub.className = "event-subtitle";
-    var next = ev.showings && ev.showings[0];
-    var sp = [CATEGORY_LABELS[ev.type] || (ev.type || "").replace(/_/g, " ")];
-    var venueLabel = ev.venue_display_name || ev.venue;
-    if (venueLabel) sp.unshift(venueLabel);
-    if (next) sp.push(formatDate(next.date) + (next.time ? " · " + formatTime(next.time) : ""));
-    sub.textContent = sp.join(" · ");
-    col.appendChild(sub);
+    col.appendChild(buildSubtitle(ev, { includeNext: true }));
 
     /* task-T3.1: surface the venue's street address on a secondary line
        so logistics-focused users can see where to go without expanding. */
@@ -2210,7 +2382,10 @@
 
     var panel = document.createElement("div");
     panel.className = "event-panel";
-    if (ev.one_liner) {
+    // The hook is generated from the same thin material as the review, so it
+    // can be a non-judgement too ("An artist talk with no named artist or
+    // described work offers no basis for review"). Nothing beats that.
+    if (ev.one_liner && !isNonJudgement(ev.one_liner)) {
       var ol = document.createElement("p");
       ol.className = "event-oneliner";
       ol.textContent = ev.one_liner;
@@ -2247,7 +2422,9 @@
       panel.appendChild(reviewWrap);
     } else if (ev.description) {
       var flat = ev.description.replace(/<[^>]*>/g, "");
-      if (flat && flat !== ev.one_liner) {
+      // Don't fall back to the raw text when the whole review was the model
+      // saying it had nothing to judge - that is what parseReview just removed.
+      if (flat && flat !== ev.one_liner && !isNonJudgement(flat)) {
         var p = document.createElement("p");
         p.className = "event-review-body";
         p.innerHTML = formatReviewBody(flat, ev);
@@ -2295,12 +2472,8 @@
     card.className = "event-card";
     var header = document.createElement("div");
     header.className = "event-header";
-    var badge = document.createElement("span");
-    var displayRating = ev.rating > 0 ? ev.rating : (ev._derivedRating || 5);
-    badge.className = "event-rating-badge rating-" + ratingClass(displayRating);
-    badge.textContent = displayRating + " / 10";
-    badge.setAttribute("aria-label", "rated " + displayRating + " out of 10");
-    header.appendChild(badge);
+    if (!isScored(ev)) card.classList.add("event-card-unscored");
+    appendRatingBadge(header, ev);
 
     var col = document.createElement("div");
     col.className = "event-title-col";
@@ -2316,19 +2489,13 @@
     } else { title.textContent = ev.title; }
     col.appendChild(title);
 
-    var sub = document.createElement("div");
-    sub.className = "event-subtitle";
-    var sp = [];
-    var venueLabel = ev.venue_display_name || ev.venue;
-    if (venueLabel) sp.push(venueLabel);
-    sp.push(CATEGORY_LABELS[ev.type] || ev.type.replace(/_/g, " "));
     // task-T8.3: show director for movie events
+    var extras = [];
     if ((ev.type || "").toLowerCase() === "movie") {
       var director = extractDirector(ev.description);
-      if (director) sp.push("dir. " + director);
+      if (director) extras.push("dir. " + director);
     }
-    sub.textContent = sp.join(" · ");
-    col.appendChild(sub);
+    col.appendChild(buildSubtitle(ev, { extras: extras }));
 
     /* task-T3.1: street address rendered below the subtitle so the
        full venue location is visible on the card face without needing
@@ -2363,7 +2530,10 @@
 
     var panel = document.createElement("div");
     panel.className = "event-panel";
-    if (ev.one_liner) {
+    // The hook is generated from the same thin material as the review, so it
+    // can be a non-judgement too ("An artist talk with no named artist or
+    // described work offers no basis for review"). Nothing beats that.
+    if (ev.one_liner && !isNonJudgement(ev.one_liner)) {
       var ol = document.createElement("p");
       ol.className = "event-oneliner";
       ol.textContent = ev.one_liner;
@@ -2400,7 +2570,9 @@
       panel.appendChild(reviewWrap);
     } else if (ev.description) {
       var flat = ev.description.replace(/<[^>]*>/g, "");
-      if (flat && flat !== ev.one_liner) {
+      // Don't fall back to the raw text when the whole review was the model
+      // saying it had nothing to judge - that is what parseReview just removed.
+      if (flat && flat !== ev.one_liner && !isNonJudgement(flat)) {
         var p = document.createElement("p");
         p.className = "event-review-body";
         p.innerHTML = formatReviewBody(flat, ev);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -382,6 +382,40 @@ body {
 .pick-rating--mid, .rating-mid { background: var(--mid); }
 .pick-rating--low, .rating-low { background: var(--lo); }
 
+/* Cards for categories we do not score (everything but film).
+
+   No badge, so the header reclaims the 72px rating column. A rule down the
+   left edge replaces the badge as the card's visual anchor, otherwise the row
+   reads as a film card with a missing score rather than a deliberately
+   different kind of listing. */
+.event-card-unscored {
+  border-left: 3px solid var(--accent);
+}
+
+.event-card-unscored .event-header {
+  grid-template-columns: 1fr 28px;
+}
+
+/* How long is left on a run - the useful, knowable fact that stands in for a
+   score on an exhibition. Emphasised only when the show is nearly down. */
+.event-run-note {
+  font-family: var(--sans);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.event-run-note::before {
+  content: " · ";
+  color: var(--muted);
+}
+
+.event-run-note.is-closing-soon {
+  color: var(--lo);
+  font-weight: 700;
+}
+
 .pick-title { font-size: 16px; font-weight: 600; }
 .pick-title a { color: var(--ink); text-decoration: none; border-bottom: 2px solid var(--accent); }
 
@@ -502,6 +536,17 @@ body {
 .picks-list.top-picks .event-card .event-header {
   grid-template-columns: 40px 72px 1fr 28px;
 }
+
+/* Same card without the rating column. Needs to beat the rule above on
+   specificity, otherwise the title is squeezed into the vacated 72px.
+   The rank counter goes too: in an urgency-ordered list a big "1" next to the
+   first item reads as "best", which is the exact claim we stopped making. */
+.picks-list.top-picks .event-card.event-card-unscored .event-header {
+  grid-template-columns: 1fr 28px;
+}
+.picks-list.top-picks .event-card.event-card-unscored .event-header::before {
+  content: none;
+}
 .picks-list.top-picks .event-card .event-header::before {
   content: counter(pick);
   font-family: var(--sans);
@@ -513,6 +558,11 @@ body {
 .picks-list.top-picks .event-card.is-open .expand-indicator {
   transform: rotate(90deg);
   color: var(--accent);
+}
+/* The 126px indent aligns the panel under the title column, past the rank and
+   rating cells. Neither exists on an unscored card, so it indents to nothing. */
+.picks-list.top-picks .event-card.event-card-unscored.is-open .event-panel {
+  padding-left: 16px;
 }
 .picks-list.top-picks .event-card.is-open .event-panel {
   max-height: 2000px;

--- a/tests/test_feature_inventory.py
+++ b/tests/test_feature_inventory.py
@@ -1,0 +1,65 @@
+"""The feature inventory must actually parse.
+
+CLAUDE.md makes config/feature-inventory.json the canonical list of
+user-visible features, appended to before every UI change and asserted against
+the live site by the continuity persona. None of that works if the file is not
+valid JSON - and it silently was not: a stray "}," sat mid-file through many
+commits because nothing in the suite ever loaded it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+INVENTORY_PATH = Path(__file__).resolve().parents[1] / "config" / "feature-inventory.json"
+
+REQUIRED_FIELDS = ("id", "name", "selector", "since_commit", "smoke_assertion")
+
+# CLAUDE.md documents three forms, but the file has grown several more that the
+# persona runner understands. Pinned as observed rather than as documented, so
+# this catches a typo without rejecting entries that already work.
+VALID_ASSERTION_PREFIXES = (
+    "selector_exists",  # also covers selector_exists_after_expand and the
+                        # selector_exists_if_* conditional variants
+    "contains_text:",
+    "js_truthy:",
+    "selector_min_count",
+    "click_then_visible",
+)
+
+
+@pytest.fixture(scope="module")
+def entries() -> list:
+    return json.loads(INVENTORY_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_inventory_is_valid_json(entries: list) -> None:
+    assert isinstance(entries, list) and entries
+
+
+@pytest.mark.unit
+def test_every_entry_has_the_required_fields(entries: list) -> None:
+    for entry in entries:
+        missing = [f for f in REQUIRED_FIELDS if not entry.get(f)]
+        assert not missing, f"{entry.get('id', '<no id>')} missing {missing}"
+
+
+@pytest.mark.unit
+def test_ids_are_unique(entries: list) -> None:
+    ids = [e["id"] for e in entries]
+    dupes = {i for i in ids if ids.count(i) > 1}
+    assert not dupes, f"duplicate feature ids: {sorted(dupes)}"
+
+
+@pytest.mark.unit
+def test_smoke_assertions_use_a_known_form(entries: list) -> None:
+    """Guards against a typo'd assertion that the persona would silently skip."""
+    for entry in entries:
+        assertion = entry["smoke_assertion"]
+        assert assertion.startswith(VALID_ASSERTION_PREFIXES), (
+            f"{entry['id']} has an unrecognised smoke_assertion: {assertion!r}"
+        )

--- a/tests/test_scoreless_categories.py
+++ b/tests/test_scoreless_categories.py
@@ -1,0 +1,231 @@
+"""Structural tests for the no-score presentation of non-film categories.
+
+Background: the 0-10 AI rating only carries signal for film. Measured across
+the published corpus, film reviews decline to judge 19% of the time and the
+scores use the whole 0-10 range; concert declines 73% of the time and visual
+arts 56%, both clustered flat around 3.4. In those categories the model is
+scoring how much material it could find, not how good the work is - a gallery
+show described only by title and venue scores low whatever is on the walls.
+
+So the site shows no score there, and must not reintroduce one: not as a badge,
+not as a fabricated venue-average fallback, and not as a "top picks" ranking
+claim over an unranked list.
+
+Same no-dependency structural strategy as test_venue_card_rendering: the
+relevant function bodies are brace-matched out of docs/script.js.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "docs" / "script.js"
+STYLES_PATH = REPO_ROOT / "docs" / "styles.css"
+
+
+def _extract_function_body(source: str, signature: str) -> str:
+    idx = source.index(signature)
+    open_brace = source.index("{", idx)
+    depth = 0
+    for i in range(open_brace, len(source)):
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace : i + 1]
+    raise AssertionError(f"unterminated function body for {signature!r}")
+
+
+@pytest.fixture(scope="module")
+def script_source() -> str:
+    return SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def css_source() -> str:
+    return STYLES_PATH.read_text(encoding="utf-8")
+
+
+# --- which categories are scored -----------------------------------------
+
+
+@pytest.mark.unit
+def test_only_film_is_scored(script_source: str) -> None:
+    """Film is the sole scored category. Adding another needs the evidence."""
+    match = re.search(r"var SCORED_CATEGORIES\s*=\s*\{([^}]*)\}", script_source)
+    assert match, "SCORED_CATEGORIES must be declared"
+    keys = re.findall(r"(\w+)\s*:", match.group(1))
+    assert keys == ["movie"], f"expected only 'movie' to be scored, got {keys}"
+
+
+@pytest.mark.unit
+def test_is_scored_helper_exists(script_source: str) -> None:
+    assert "function isScored(" in script_source
+
+
+# --- the badge -----------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_badge_is_gated_on_is_scored(script_source: str) -> None:
+    """The rating badge must not render for an unscored category."""
+    body = _extract_function_body(script_source, "function appendRatingBadge")
+    assert re.search(
+        r"if\s*\(\s*!\s*isScored\(ev\)\s*\)\s*return", body
+    ), "appendRatingBadge must bail out early for unscored events"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("builder", ["buildPickCard", "buildListingCard"])
+def test_card_builders_do_not_inline_a_badge(script_source: str, builder: str) -> None:
+    """Both card faces must go through the gated helper.
+
+    Guards the specific regression this replaced: each builder used to inline
+    `ev.rating > 0 ? ev.rating : (ev._derivedRating || 5)` and always append a
+    badge, so an unscored event displayed a fabricated 5.
+    """
+    body = _extract_function_body(script_source, "function " + builder)
+    assert "appendRatingBadge(" in body, f"{builder} must use appendRatingBadge"
+    assert "event-rating-badge" not in body, (
+        f"{builder} must not build a badge inline; that path skips the isScored gate"
+    )
+
+
+# --- no fabricated ratings ----------------------------------------------
+
+
+@pytest.mark.unit
+def test_derived_rating_only_applies_to_scored_categories(script_source: str) -> None:
+    """The venue-average fallback must never reach an unscored event.
+
+    Inventing a number for a gallery show puts a fabricated value in exactly
+    the place a real judgement goes, which is worse than showing nothing.
+    """
+    body = _extract_function_body(script_source, "function renderAll")
+    assert re.search(
+        r"isScored\(ev\)\s*&&[\s\S]{0,120}?_derivedRating\s*=\s*derivedRating", body
+    ), "renderAll must gate derivedRating on isScored"
+
+
+# --- ordering ------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unscored_events_sort_by_urgency(script_source: str) -> None:
+    """Unscored events order by date, not by a rating they do not have."""
+    body = _extract_function_body(script_source, "function groupEvents")
+    assert "urgencyDate(" in body, "groupEvents must sort unscored events by urgencyDate"
+    assert "isScored(" in body, "groupEvents must branch on whether a category is scored"
+
+
+@pytest.mark.unit
+def test_urgency_prefers_end_date_for_a_running_show(script_source: str) -> None:
+    """A months-long exhibition is urgent when it closes, not when it opened."""
+    body = _extract_function_body(script_source, "function urgencyDate")
+    assert re.search(
+        r"first\s*<=\s*today[\s\S]{0,60}?return\s+end", body
+    ), "urgencyDate must return the closing date for a show already open"
+
+
+# --- ranking claims ------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_picks_heading_drops_the_ranking_claim(script_source: str) -> None:
+    """"Top picks" is a ranking claim; an unranked list must not make it."""
+    body = _extract_function_body(script_source, "function renderPicks")
+    assert "TOP PICKS OF THE WEEK" in body and "ON THIS WEEK" in body, (
+        "renderPicks must swap the heading when nothing in the list is scored"
+    )
+    assert "isScored" in body
+
+
+@pytest.mark.unit
+def test_rank_counter_hidden_for_unscored_picks(css_source: str) -> None:
+    """A big '1' beside the first item reads as 'best'."""
+    assert re.search(
+        r"\.event-card-unscored\s+\.event-header::before\s*\{\s*content:\s*none",
+        css_source,
+    ), "the pick rank counter must be suppressed on unscored cards"
+
+
+# --- layout --------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_unscored_card_reclaims_the_rating_column(css_source: str) -> None:
+    """Without this the title is squeezed into the vacated badge column."""
+    assert ".event-card-unscored .event-header" in css_source
+    assert re.search(
+        r"\.picks-list\.top-picks \.event-card\.event-card-unscored \.event-header\s*\{",
+        css_source,
+    ), "the picks variant needs its own grid override to beat the base rule"
+
+
+@pytest.mark.unit
+def test_run_note_style_exists(css_source: str) -> None:
+    assert re.search(r"\.event-run-note\s*\{", css_source)
+    assert re.search(r"\.event-run-note\.is-closing-soon\s*\{", css_source)
+
+
+# --- non-judgement suppression -------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_judgement_detector_exists(script_source: str) -> None:
+    assert "NON_JUDGEMENT_RE" in script_source
+    assert "function isNonJudgement(" in script_source
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "There is not enough evidence in the supplied material to judge composition",
+        "I cannot assess composition, materials, technique, or installation",
+        "The available information does not describe the actual works",
+        "no basis for crediting composition or technique",
+        "the provided sources do not include an exhibition description",
+        "its cultural significance is limited by the thin public record",
+        "the exhibition remains undocumented rather than conceptually legible",
+        "I cannot fairly credit originality from the available record",
+    ],
+)
+def test_detector_matches_real_non_judgements(script_source: str, phrase: str) -> None:
+    """Every phrase here was published on the live site under a critic heading."""
+    match = re.search(r"var NON_JUDGEMENT_RE = new RegExp\(\[([\s\S]*?)\]\.join", script_source)
+    assert match, "NON_JUDGEMENT_RE must be a joined list of alternatives"
+    alternatives = re.findall(r'"((?:[^"\\]|\\.)*)"', match.group(1))
+    pattern = re.compile("|".join(alternatives).replace("\\\\b", "\\b"), re.IGNORECASE)
+    assert pattern.search(phrase), f"detector must catch: {phrase!r}"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "A juried survey of contemporary printmaking, and that is its strength.",
+        "Treviño draws from her experience as a mother, interrogating media narratives.",
+        "The exhibition is a juried PrintAustin show, so its value lies in the friction.",
+    ],
+)
+def test_detector_leaves_real_criticism_alone(script_source: str, phrase: str) -> None:
+    """A genuine review must survive - this filter removes content."""
+    match = re.search(r"var NON_JUDGEMENT_RE = new RegExp\(\[([\s\S]*?)\]\.join", script_source)
+    alternatives = re.findall(r'"((?:[^"\\]|\\.)*)"', match.group(1))
+    pattern = re.compile("|".join(alternatives).replace("\\\\b", "\\b"), re.IGNORECASE)
+    assert not pattern.search(phrase), f"detector must not swallow real criticism: {phrase!r}"
+
+
+@pytest.mark.unit
+def test_one_liner_is_filtered_too(script_source: str) -> None:
+    """The hook is generated from the same thin material as the review."""
+    assert re.search(
+        r"if\s*\(ev\.one_liner\s*&&\s*!isNonJudgement\(ev\.one_liner\)\)", script_source
+    ), "the one-liner must be suppressed when it is itself a non-judgement"

--- a/tests/test_venue_card_rendering.py
+++ b/tests/test_venue_card_rendering.py
@@ -67,25 +67,33 @@ def listing_card_body(script_source: str) -> str:
     return _extract_function_body(script_source, "function buildListingCard")
 
 
+@pytest.fixture(scope="module")
+def subtitle_body(script_source: str) -> str:
+    return _extract_function_body(script_source, "function buildSubtitle")
+
+
 # --- venue_display_name primary label with fallback ----------------------
+#
+# The two builders used to each carry their own copy of the subtitle logic.
+# They now share buildSubtitle, so the fallback is asserted once where it
+# lives, plus a check that both builders actually route through it - which is
+# what keeps this behavioural rather than a test of where code sits.
 
 
 @pytest.mark.unit
-def test_pick_card_uses_venue_display_name_with_fallback(pick_card_body: str) -> None:
-    """buildPickCard prefers venue_display_name, falls back to raw venue."""
+def test_subtitle_uses_venue_display_name_with_fallback(subtitle_body: str) -> None:
+    """The shared subtitle prefers venue_display_name, falls back to raw venue."""
     assert re.search(
-        r"ev\.venue_display_name\s*\|\|\s*ev\.venue", pick_card_body
-    ), "buildPickCard must use venue_display_name with a fallback to venue"
+        r"ev\.venue_display_name\s*\|\|\s*ev\.venue", subtitle_body
+    ), "buildSubtitle must use venue_display_name with a fallback to venue"
 
 
 @pytest.mark.unit
-def test_listing_card_uses_venue_display_name_with_fallback(
-    listing_card_body: str,
-) -> None:
-    """buildListingCard prefers venue_display_name, falls back to raw venue."""
-    assert re.search(
-        r"ev\.venue_display_name\s*\|\|\s*ev\.venue", listing_card_body
-    ), "buildListingCard must use venue_display_name with a fallback to venue"
+@pytest.mark.parametrize("builder", ["buildPickCard", "buildListingCard"])
+def test_card_builders_use_the_shared_subtitle(script_source: str, builder: str) -> None:
+    """Both card faces must render their venue line through buildSubtitle."""
+    body = _extract_function_body(script_source, "function " + builder)
+    assert "buildSubtitle(" in body, f"{builder} must build its subtitle via buildSubtitle"
 
 
 # --- conditional .event-venue-address rendering --------------------------


### PR DESCRIPTION
You were right that the 0-10 rating does not belong on visual arts. The data says it is worse than that.

## The evidence

Share of reviews where the model **explicitly declines to judge**, against how much the score actually spreads:

| category | declines | mean | range |
|---|---|---|---|
| movie | 19% | 5.9 | 0-10 |
| dance | 32% | 4.0 | 0-5 |
| visual_arts | 56% | 3.4 | 1-7 |
| opera | 58% | 5.2 | 0-9 |
| **concert** | **73%** | 3.5 | 0-8 |

Film is the only category where the number carries signal. Everywhere else the model is scoring *how much material it could find*, not how good the work is — a gallery show described by title and venue alone scores low whatever is on the walls. Concert is the worst offender, worse than visual arts.

Worth seeing what was actually shipping, `review_confidence: "high"`:

> ★ Rating: 4/10 🎭 Formal Qualities **There is not enough evidence in the supplied material to judge composition, materials, technique, or installation with confidence.**

So: **film keeps its score and nothing else has one.**

## What replaces it

Unscored events sort by urgency instead of a rating they don't have — a show already open sorts by when it *closes*, one not yet open by when it *opens*, both ascending. The list reads "what you're about to miss, then what's coming." Cards carry a run note (`Through Sep 12`, `Closes` when nearly down) and lead with artist, medium and venue.

## Three ways a score was leaking in

- Unscored events got a **fabricated** rating — the venue average, or a flat 5 — so every card had a badge and the list stayed sortable. A made-up number in the exact place a real judgement goes.
- **"Top picks of the week"** is a ranking claim. Filtered to Visual Arts it ranked an unrankable list. Heading now reads **"On this week"** when nothing in it is scored.
- The **rank counter** beside each pick reads as "best". Gone for unscored.

Reviews that decline to judge are no longer rendered as criticism. What they share is that they discuss *the record* rather than *the work*, so that's what's matched on rather than enumerating phrasings. The one-liner is filtered too — same thin material ("An artist talk with no named artist or described work offers no basis for review").

## Verified in a browser

Against the live corpus: **24 visual arts cards, zero badges, zero non-judgement panels, none left empty** by the filtering. Film untouched — **108 cards, all badged, still ranked**.

## Two things found along the way

**`config/feature-inventory.json` has been invalid JSON on `main`** — a stray `},` mid-file. It is meant to be the canonical record of user-visible features and is asserted against the live site; none of that works if it doesn't parse. Nothing in the suite loaded it, so it rotted silently. Fixed, plus a test that parses it.

**The live-site persona gate was running 4/6.** Pushing this branch surfaced it: `continuity-user` pointed at an image-only Gemini preview with no tool support, `mobile-user` at a deprecated Xiaomi model. Both 404'd and dropped out silently while the council still reported ACCEPT. `continuity-user` is the lens that exists *because features were previously dropped unnoticed* — a gate against silent removals had itself been silently removed. All six now pass, six distinct non-Anthropic families.

## Scope

Presentation only. Ratings are still generated and still drive the weekly tipsheet's picks, which has the same problem for non-film events — worth a separate look.

**Tests: 1009 passing.** `verify_calendar.py --offline` green. Live-site council 6/6 ACCEPT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiRjoaFnyMRWNXb2qmXYEX